### PR TITLE
Introduce event action that clear zero-energy PHG4Hits, which is not associated with truth hits

### DIFF
--- a/simulation/g4simulation/g4detectors/PHG4ForwardEcalSubsystem.cc
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardEcalSubsystem.cc
@@ -1,6 +1,7 @@
 #include "PHG4ForwardEcalSubsystem.h"
 #include "PHG4ForwardEcalDetector.h"
 #include "PHG4ForwardEcalSteppingAction.h"
+#include "PHG4EventActionClearZeroEdep.h"
 
 #include <g4main/PHG4HitContainer.h>
 #include <phool/getClass.h>
@@ -8,6 +9,7 @@
 #include <Geant4/globals.hh>
 
 #include <sstream>
+#include <boost/foreach.hpp>
 
 using namespace std;
 
@@ -45,6 +47,8 @@ int PHG4ForwardEcalSubsystem::Init( PHCompositeNode* topNode )
 
   if (active)
     {
+      set<string> nodes;
+
       // create hit output node
       ostringstream nodename;
       nodename <<  "G4HIT_" << detector_type;
@@ -55,6 +59,7 @@ int PHG4ForwardEcalSubsystem::Init( PHCompositeNode* topNode )
           scintillator_hits = new PHG4HitContainer();
           PHIODataNode<PHObject> *hitNode = new PHIODataNode<PHObject>(scintillator_hits, nodename.str().c_str(), "PHObject");
           dstNode->addNode(hitNode);
+          nodes.insert(nodename.str());
         }
 
       ostringstream absnodename;
@@ -66,10 +71,26 @@ int PHG4ForwardEcalSubsystem::Init( PHCompositeNode* topNode )
           absorber_hits = new PHG4HitContainer();
           PHIODataNode<PHObject> *abshitNode = new PHIODataNode<PHObject>(absorber_hits, absnodename.str().c_str(), "PHObject");
           dstNode->addNode(abshitNode);
+          nodes.insert(nodename.str());
         }
 
       // create stepping action
       steppingAction_ = new PHG4ForwardEcalSteppingAction(detector_);
+
+      // event actions
+      BOOST_FOREACH(string node, nodes)
+        {
+          if (!eventAction_)
+            {
+              eventAction_ = new PHG4EventActionClearZeroEdep(topNode, node);
+            }
+          else
+            {
+              PHG4EventActionClearZeroEdep *evtact =
+                  dynamic_cast<PHG4EventActionClearZeroEdep *>(eventAction_);
+              evtact->AddNode(node);
+            }
+        }
     }
 
   return 0;

--- a/simulation/g4simulation/g4detectors/PHG4ForwardEcalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardEcalSubsystem.h
@@ -37,8 +37,9 @@ public:
 
   /** Accessors (reimplemented)
    */
-  virtual PHG4Detector* GetDetector( void ) const;
-  virtual PHG4SteppingAction* GetSteppingAction( void ) const;
+  PHG4Detector* GetDetector( void ) const;
+  PHG4SteppingAction* GetSteppingAction( void ) const;
+  PHG4EventAction* GetEventAction() const {return eventAction_;}
 
   /** Set mapping file for calorimeter towers
    */

--- a/simulation/g4simulation/g4detectors/PHG4ForwardHcalSubsystem.h
+++ b/simulation/g4simulation/g4detectors/PHG4ForwardHcalSubsystem.h
@@ -37,8 +37,9 @@ public:
 
   /** Accessors (reimplemented)
    */
-  virtual PHG4Detector* GetDetector( void ) const;
-  virtual PHG4SteppingAction* GetSteppingAction( void ) const;
+  PHG4Detector* GetDetector( void ) const;
+  PHG4SteppingAction* GetSteppingAction( void ) const;
+  PHG4EventAction* GetEventAction() const {return eventAction_;}
 
   /** Set mapping file for calorimeter towers
    */


### PR DESCRIPTION
One last fix for a minor problem. If zero-edep hits are not cleared, they could be not assocaited with any truth track and upsets downstream truth tracing code. 

@johnlajoie you are welcome to accept this proposed fix by clicking "Merge Pull Request" button here. Then this update will also be automatically brought up to the https://github.com/sPHENIX-Collaboration/coresoftware/pull/97 
