### PR TITLE
Pathlength extraction

### DIFF
--- a/offline/packages/PHGenFitPkg/PHGenFit/Track.cc
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Track.cc
@@ -61,7 +61,7 @@ Track::~Track()
 	delete _track;
 }
 
-double Track::extrapolateToPlane(genfit::MeasuredStateOnPlane* state, TVector3 O, TVector3 n, const int tr_point_id) const
+double Track::extrapolateToPlane(genfit::MeasuredStateOnPlane& state, TVector3 O, TVector3 n, const int tr_point_id) const
 {
 	double pathlenth = -9999;
 
@@ -74,32 +74,30 @@ double Track::extrapolateToPlane(genfit::MeasuredStateOnPlane* state, TVector3 O
 		std::cout << "Track has no TrackPoint with fitterInfo! \n";
 		return pathlenth;
 	}
-
-	state = new genfit::KalmanFittedStateOnPlane(
+	genfit::KalmanFittedStateOnPlane *kfsop  = new genfit::KalmanFittedStateOnPlane(
 			*(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(rep))->getBackwardUpdate()));
 	// extrapolate back to reference plane.
 	try {
-		pathlenth = rep->extrapolateToPlane(*state, destPlane);
+		pathlenth = rep->extrapolateToPlane(*kfsop, destPlane);
 	} catch (genfit::Exception& e) {
 		std::cerr << "Exception, next track" << std::endl;
 		std::cerr << e.what();
 		return -9999;
 	}
+
+	state = *dynamic_cast<genfit::MeasuredStateOnPlane*> (kfsop);
 
 	return pathlenth;
 }
 
 genfit::MeasuredStateOnPlane* Track::extrapolateToPlane(TVector3 O, TVector3 n, const int tr_point_id) const
 {
-	genfit::MeasuredStateOnPlane* state = NULL;
-	double pathlenth = this->extrapolateToPlane(state, O, n, tr_point_id);
-	if (pathlenth > 0)
-		return state;
-	else
-		return NULL;
+	genfit::MeasuredStateOnPlane* state = new genfit::MeasuredStateOnPlane();
+	this->extrapolateToPlane(*state, O, n, tr_point_id);
+	return state;
 }
 
-double Track::extrapolateToLine(genfit::MeasuredStateOnPlane* state, TVector3 line_point, TVector3 line_direction, const int tr_point_id) const
+double Track::extrapolateToLine(genfit::MeasuredStateOnPlane& state, TVector3 line_point, TVector3 line_direction, const int tr_point_id) const
 {
 	double pathlenth = -9999;
 
@@ -110,31 +108,32 @@ double Track::extrapolateToLine(genfit::MeasuredStateOnPlane* state, TVector3 li
 		std::cout << "Track has no TrackPoint with fitterInfo! \n";
 		return -9999;
 	}
-	state = new genfit::KalmanFittedStateOnPlane(
+	genfit::KalmanFittedStateOnPlane *kfsop = new genfit::KalmanFittedStateOnPlane(
 			*(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(rep))->getBackwardUpdate()));
 	// extrapolate back to reference plane.
 	try {
-		pathlenth = rep->extrapolateToLine(*state, line_point, line_direction);
+		pathlenth = rep->extrapolateToLine(*kfsop, line_point, line_direction);
 	} catch (genfit::Exception& e) {
 		std::cerr << "Exception, next track" << std::endl;
 		std::cerr << e.what();
 		return -9999;
 	}
+
+	state = *dynamic_cast<genfit::MeasuredStateOnPlane*> (kfsop);
+
 
 	return pathlenth;
 }
 
 genfit::MeasuredStateOnPlane* Track::extrapolateToLine(TVector3 line_point, TVector3 line_direction, const int tr_point_id) const
 {
-	genfit::MeasuredStateOnPlane* state = NULL;
-	double pathlenth = this->extrapolateToLine(state, line_point, line_direction, tr_point_id);
-	if (pathlenth > 0)
-		return state;
-	else
-		return NULL;
+	genfit::MeasuredStateOnPlane* state = new genfit::MeasuredStateOnPlane();
+	this->extrapolateToLine(*state, line_point, line_direction, tr_point_id);
+	return state;
+
 }
 
-double Track::extrapolateToCylinder(genfit::MeasuredStateOnPlane* state, double radius, TVector3 line_point, TVector3 line_direction, const int tr_point_id) const
+double Track::extrapolateToCylinder(genfit::MeasuredStateOnPlane& state, double radius, TVector3 line_point, TVector3 line_direction, const int tr_point_id) const
 {
 	double pathlenth = -9999;
 
@@ -145,32 +144,31 @@ double Track::extrapolateToCylinder(genfit::MeasuredStateOnPlane* state, double 
 		std::cout << "Track has no TrackPoint with fitterInfo! \n";
 		return -9999;
 	}
-	state = new genfit::KalmanFittedStateOnPlane(
+	genfit::KalmanFittedStateOnPlane *kfsop = new genfit::KalmanFittedStateOnPlane(
 			*(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(rep))->getForwardUpdate()));
 	// extrapolate back to reference plane.
 	try {
 		//rep->extrapolateToLine(*kfsop, line_point, line_direction);
-		pathlenth = rep->extrapolateToCylinder(*state, radius, line_point, line_direction);
+		pathlenth = rep->extrapolateToCylinder(*kfsop, radius, line_point, line_direction);
 	} catch (genfit::Exception& e) {
 		std::cerr << "Exception, next track" << std::endl;
 		std::cerr << e.what();
 		return -9999;
 	}
+
+	state = *dynamic_cast<genfit::MeasuredStateOnPlane*> (kfsop);
 
 	return pathlenth;
 }
 
 genfit::MeasuredStateOnPlane*  Track::extrapolateToCylinder(double radius, TVector3 line_point, TVector3 line_direction, const int tr_point_id) const
 {
-	genfit::MeasuredStateOnPlane* state = NULL;
-	double pathlenth = this->extrapolateToCylinder(state, radius, line_point, line_direction);
-	if (pathlenth > 0)
-		return state;
-	else
-		return NULL;
+	genfit::MeasuredStateOnPlane* state = new genfit::MeasuredStateOnPlane();
+	this->extrapolateToCylinder(*state, radius, line_point, line_direction);
+	return state;
 }
 
-double Track::extrapolateToPoint(genfit::MeasuredStateOnPlane* state, TVector3 P, const int tr_point_id) const
+double Track::extrapolateToPoint(genfit::MeasuredStateOnPlane& state, TVector3 P, const int tr_point_id) const
 {
 	double pathlenth = -9999;
 	genfit::AbsTrackRep* rep = _track->getCardinalRep();
@@ -180,27 +178,26 @@ double Track::extrapolateToPoint(genfit::MeasuredStateOnPlane* state, TVector3 P
 		std::cout << "Track has no TrackPoint with fitterInfo! \n";
 		return -9999;
 	}
-	state = new genfit::KalmanFittedStateOnPlane(
+	genfit::KalmanFittedStateOnPlane *kfsop = new genfit::KalmanFittedStateOnPlane(
 			*(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(rep))->getBackwardUpdate()));
 	// extrapolate back to reference plane.
 	try {
-		pathlenth = rep->extrapolateToPoint(*state, P);
+		pathlenth = rep->extrapolateToPoint(*kfsop, P);
 	} catch (genfit::Exception& e) {
 		std::cerr << "Exception, next track" << std::endl;
 		std::cerr << e.what();
 		return -9999;
 	}
 
+	state = *dynamic_cast<genfit::MeasuredStateOnPlane*> (kfsop);
+
 	return pathlenth;
 }
 
 genfit::MeasuredStateOnPlane*  Track::extrapolateToPoint(TVector3 P, const int tr_point_id) const
 {
-	genfit::MeasuredStateOnPlane* state = NULL;
-	double pathlenth = this->extrapolateToPoint(state, P, tr_point_id);
-	if (pathlenth > 0)
-		return state;
-	else
-		return NULL;
+	genfit::MeasuredStateOnPlane* state = new genfit::MeasuredStateOnPlane();
+	this->extrapolateToPoint(*state, P, tr_point_id);
+	return state;
 }
 } //End of PHGenFit namespace

--- a/offline/packages/PHGenFitPkg/PHGenFit/Track.cc
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Track.cc
@@ -23,6 +23,8 @@
 #define LogError(exp)		std::cout<<"ERROR: "<<__FILE__<<": "<<__LINE__<<": "<< exp <<"\n"
 #define LogWarning(exp)	std::cout<<"WARNING: "<<__FILE__<<": "<<__LINE__<<": "<< exp <<"\n"
 
+#define WILD_DOUBLE -999999
+
 
 namespace PHGenFit {
 
@@ -63,7 +65,7 @@ Track::~Track()
 
 double Track::extrapolateToPlane(genfit::MeasuredStateOnPlane& state, TVector3 O, TVector3 n, const int tr_point_id) const
 {
-	double pathlenth = -9999;
+	double pathlenth = WILD_DOUBLE;
 
 	genfit::SharedPlanePtr destPlane(new genfit::DetPlane(O, n));
 
@@ -72,7 +74,7 @@ double Track::extrapolateToPlane(genfit::MeasuredStateOnPlane& state, TVector3 O
 			tr_point_id, rep);
 	if (tp == NULL) {
 		std::cout << "Track has no TrackPoint with fitterInfo! \n";
-		return pathlenth;
+		return WILD_DOUBLE;
 	}
 	genfit::KalmanFittedStateOnPlane *kfsop  = new genfit::KalmanFittedStateOnPlane(
 			*(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(rep))->getBackwardUpdate()));
@@ -82,7 +84,7 @@ double Track::extrapolateToPlane(genfit::MeasuredStateOnPlane& state, TVector3 O
 	} catch (genfit::Exception& e) {
 		std::cerr << "Exception, next track" << std::endl;
 		std::cerr << e.what();
-		return -9999;
+		return WILD_DOUBLE;
 	}
 
 	state = *dynamic_cast<genfit::MeasuredStateOnPlane*> (kfsop);
@@ -93,20 +95,23 @@ double Track::extrapolateToPlane(genfit::MeasuredStateOnPlane& state, TVector3 O
 genfit::MeasuredStateOnPlane* Track::extrapolateToPlane(TVector3 O, TVector3 n, const int tr_point_id) const
 {
 	genfit::MeasuredStateOnPlane* state = new genfit::MeasuredStateOnPlane();
-	this->extrapolateToPlane(*state, O, n, tr_point_id);
-	return state;
+	double pathlenth = this->extrapolateToPlane(*state, O, n, tr_point_id);
+	if(pathlenth <= WILD_DOUBLE)
+		return NULL;
+	else
+		return state;
 }
 
 double Track::extrapolateToLine(genfit::MeasuredStateOnPlane& state, TVector3 line_point, TVector3 line_direction, const int tr_point_id) const
 {
-	double pathlenth = -9999;
+	double pathlenth = WILD_DOUBLE;
 
 	genfit::AbsTrackRep* rep = _track->getCardinalRep();
 	genfit::TrackPoint* tp = _track->getPointWithMeasurementAndFitterInfo(
 			tr_point_id, rep);
 	if (tp == NULL) {
 		std::cout << "Track has no TrackPoint with fitterInfo! \n";
-		return -9999;
+		return WILD_DOUBLE;
 	}
 	genfit::KalmanFittedStateOnPlane *kfsop = new genfit::KalmanFittedStateOnPlane(
 			*(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(rep))->getBackwardUpdate()));
@@ -116,7 +121,7 @@ double Track::extrapolateToLine(genfit::MeasuredStateOnPlane& state, TVector3 li
 	} catch (genfit::Exception& e) {
 		std::cerr << "Exception, next track" << std::endl;
 		std::cerr << e.what();
-		return -9999;
+		return WILD_DOUBLE;
 	}
 
 	state = *dynamic_cast<genfit::MeasuredStateOnPlane*> (kfsop);
@@ -128,21 +133,23 @@ double Track::extrapolateToLine(genfit::MeasuredStateOnPlane& state, TVector3 li
 genfit::MeasuredStateOnPlane* Track::extrapolateToLine(TVector3 line_point, TVector3 line_direction, const int tr_point_id) const
 {
 	genfit::MeasuredStateOnPlane* state = new genfit::MeasuredStateOnPlane();
-	this->extrapolateToLine(*state, line_point, line_direction, tr_point_id);
-	return state;
-
+	double pathlenth = this->extrapolateToLine(*state, line_point, line_direction, tr_point_id);
+	if(pathlenth <= WILD_DOUBLE)
+		return NULL;
+	else
+		return state;
 }
 
 double Track::extrapolateToCylinder(genfit::MeasuredStateOnPlane& state, double radius, TVector3 line_point, TVector3 line_direction, const int tr_point_id) const
 {
-	double pathlenth = -9999;
+	double pathlenth = WILD_DOUBLE;
 
 	genfit::AbsTrackRep* rep = _track->getCardinalRep();
 	genfit::TrackPoint* tp = _track->getPointWithMeasurementAndFitterInfo(
 			tr_point_id, rep);
 	if (tp == NULL) {
 		std::cout << "Track has no TrackPoint with fitterInfo! \n";
-		return -9999;
+		return WILD_DOUBLE;
 	}
 	genfit::KalmanFittedStateOnPlane *kfsop = new genfit::KalmanFittedStateOnPlane(
 			*(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(rep))->getForwardUpdate()));
@@ -153,7 +160,7 @@ double Track::extrapolateToCylinder(genfit::MeasuredStateOnPlane& state, double 
 	} catch (genfit::Exception& e) {
 		std::cerr << "Exception, next track" << std::endl;
 		std::cerr << e.what();
-		return -9999;
+		return WILD_DOUBLE;
 	}
 
 	state = *dynamic_cast<genfit::MeasuredStateOnPlane*> (kfsop);
@@ -164,19 +171,22 @@ double Track::extrapolateToCylinder(genfit::MeasuredStateOnPlane& state, double 
 genfit::MeasuredStateOnPlane*  Track::extrapolateToCylinder(double radius, TVector3 line_point, TVector3 line_direction, const int tr_point_id) const
 {
 	genfit::MeasuredStateOnPlane* state = new genfit::MeasuredStateOnPlane();
-	this->extrapolateToCylinder(*state, radius, line_point, line_direction);
-	return state;
+	double pathlenth = this->extrapolateToCylinder(*state, radius, line_point, line_direction);
+	if(pathlenth <= WILD_DOUBLE)
+		return NULL;
+	else
+		return state;
 }
 
 double Track::extrapolateToPoint(genfit::MeasuredStateOnPlane& state, TVector3 P, const int tr_point_id) const
 {
-	double pathlenth = -9999;
+	double pathlenth = WILD_DOUBLE;
 	genfit::AbsTrackRep* rep = _track->getCardinalRep();
 	genfit::TrackPoint* tp = _track->getPointWithMeasurementAndFitterInfo(
 			tr_point_id, rep);
 	if (tp == NULL) {
 		std::cout << "Track has no TrackPoint with fitterInfo! \n";
-		return -9999;
+		return WILD_DOUBLE;
 	}
 	genfit::KalmanFittedStateOnPlane *kfsop = new genfit::KalmanFittedStateOnPlane(
 			*(static_cast<genfit::KalmanFitterInfo*>(tp->getFitterInfo(rep))->getBackwardUpdate()));
@@ -186,7 +196,7 @@ double Track::extrapolateToPoint(genfit::MeasuredStateOnPlane& state, TVector3 P
 	} catch (genfit::Exception& e) {
 		std::cerr << "Exception, next track" << std::endl;
 		std::cerr << e.what();
-		return -9999;
+		return WILD_DOUBLE;
 	}
 
 	state = *dynamic_cast<genfit::MeasuredStateOnPlane*> (kfsop);
@@ -197,7 +207,10 @@ double Track::extrapolateToPoint(genfit::MeasuredStateOnPlane& state, TVector3 P
 genfit::MeasuredStateOnPlane*  Track::extrapolateToPoint(TVector3 P, const int tr_point_id) const
 {
 	genfit::MeasuredStateOnPlane* state = new genfit::MeasuredStateOnPlane();
-	this->extrapolateToPoint(*state, P, tr_point_id);
-	return state;
+	double pathlenth = this->extrapolateToPoint(*state, P, tr_point_id);
+	if(pathlenth <= WILD_DOUBLE)
+		return NULL;
+	else
+		return state;
 }
 } //End of PHGenFit namespace

--- a/offline/packages/PHGenFitPkg/PHGenFit/Track.h
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Track.h
@@ -44,27 +44,25 @@ public:
 	//! Add measurement
 	int addMeasurements(std::vector<PHGenFit::Measurement*> measurements);
 
+	/*!
+	 * track_point 0 is the first one, and -1 is the last one
+	 */
+	double extrapolateToPlane(genfit::MeasuredStateOnPlane& state, TVector3 O, TVector3 n, const int tr_point_id = 0) const;
 	//!
-	double extrapolateToPlane(genfit::MeasuredStateOnPlane* state, TVector3 O, TVector3 n, const int tr_point_id = -1) const;
+	double extrapolateToLine(genfit::MeasuredStateOnPlane& state, TVector3 line_point, TVector3 line_direction, const int tr_point_id = 0) const;
 	//!
-	double extrapolateToLine(genfit::MeasuredStateOnPlane* state, TVector3 line_point, TVector3 line_direction, const int tr_point_id = 0) const;
+	double extrapolateToCylinder(genfit::MeasuredStateOnPlane& state, double radius, TVector3 line_point, TVector3 line_direction, const int tr_point_id = 0) const;
 	//!
-	double extrapolateToCylinder(genfit::MeasuredStateOnPlane* state, double radius, TVector3 line_point, TVector3 line_direction, const int tr_point_id = -1) const;
-	//!
-	double extrapolateToPoint(genfit::MeasuredStateOnPlane* state, TVector3 P, const int tr_point_id = 0) const;
+	double extrapolateToPoint(genfit::MeasuredStateOnPlane& state, TVector3 P, const int tr_point_id = 0) const;
 
 	//!
-	genfit::MeasuredStateOnPlane* extrapolateToPlane(TVector3 O, TVector3 n, const int tr_point_id = -1) const;
-
+	genfit::MeasuredStateOnPlane* extrapolateToPlane(TVector3 O, TVector3 n, const int tr_point_id = 0) const;
 	//!
 	genfit::MeasuredStateOnPlane* extrapolateToLine(TVector3 line_point, TVector3 line_direction, const int tr_point_id = 0) const;
-
 	//!
-	genfit::MeasuredStateOnPlane* extrapolateToCylinder(double radius, TVector3 line_point, TVector3 line_direction, const int tr_point_id = -1) const;
-
+	genfit::MeasuredStateOnPlane* extrapolateToCylinder(double radius, TVector3 line_point, TVector3 line_direction, const int tr_point_id = 0) const;
 	//!
 	genfit::MeasuredStateOnPlane* extrapolateToPoint(TVector3 P, const int tr_point_id = 0) const;
-
 	//!
 	genfit::Track* getGenFitTrack() {return _track;}
 

--- a/offline/packages/PHGenFitPkg/PHGenFit/Track.h
+++ b/offline/packages/PHGenFitPkg/PHGenFit/Track.h
@@ -45,6 +45,15 @@ public:
 	int addMeasurements(std::vector<PHGenFit::Measurement*> measurements);
 
 	//!
+	double extrapolateToPlane(genfit::MeasuredStateOnPlane* state, TVector3 O, TVector3 n, const int tr_point_id = -1) const;
+	//!
+	double extrapolateToLine(genfit::MeasuredStateOnPlane* state, TVector3 line_point, TVector3 line_direction, const int tr_point_id = 0) const;
+	//!
+	double extrapolateToCylinder(genfit::MeasuredStateOnPlane* state, double radius, TVector3 line_point, TVector3 line_direction, const int tr_point_id = -1) const;
+	//!
+	double extrapolateToPoint(genfit::MeasuredStateOnPlane* state, TVector3 P, const int tr_point_id = 0) const;
+
+	//!
 	genfit::MeasuredStateOnPlane* extrapolateToPlane(TVector3 O, TVector3 n, const int tr_point_id = -1) const;
 
 	//!

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
@@ -569,6 +569,7 @@ SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(const PHGenFit::Track* phgf_track,
 		  out_track->set_error(i,j, gf_state->get6DCov()[i][j]);
 		}
 	    }
+	  state->identify();
 	  out_track->insert_state(state);
 	}
 

--- a/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
+++ b/simulation/g4simulation/g4hough/PHG4TrackFastSim.C
@@ -569,7 +569,6 @@ SvtxTrack* PHG4TrackFastSim::MakeSvtxTrack(const PHGenFit::Track* phgf_track,
 		  out_track->set_error(i,j, gf_state->get6DCov()[i][j]);
 		}
 	    }
-	  state->identify();
 	  out_track->insert_state(state);
 	}
 


### PR DESCRIPTION
New extrapolateToXXX methods added to PHGenFit::Track to get the track pathlength.
double extrapolateToXXX(genfit::MeasuredStateOnPlane& state
Original interface still available:
genfit::MeasuredStateOnPlane\* extrapolateToXXX

All extrapolate methods are based on the first measurement. The pathlength is also defined starting from the first measurement. So if users want to extrapolate track pathlength from some original position (z=0, beam line, vertex, etc.), they need to subtract the pathlength from original position to the first measurement.

Example output (from debugging):

Extract pathlength from original position to the first measurement:
![image](https://cloud.githubusercontent.com/assets/10383186/19652795/30495a7e-99e0-11e6-8bdd-151c8b41fafb.png)

Pathlength from the disignated position to the original position, stored in a SvtxTrackState_v1:
![image](https://cloud.githubusercontent.com/assets/10383186/19652800/355e8aa2-99e0-11e6-862a-1f3f2d688034.png)
